### PR TITLE
Allows any origin for CORS during development

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -52,7 +52,7 @@ builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.WithOrigins("http://localhost:3000")
+        policy.SetIsOriginAllowed(origin => true) // Allow any origin during development
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials();


### PR DESCRIPTION
Simplifies CORS configuration during development by allowing requests from any origin.

This change replaces the specific origin check with a wildcard to enable easier testing and development without needing to configure specific origins.